### PR TITLE
Controls documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ fints2ledger
 ```
 This will download the transactions from the last year and tries to convert them to a ledger journal.
 
-You can enter `s` on any transaction prompt to skip the transaction and return to it on the next run.
-
 A list of available command line arguments:
 ```
 usage: fints2ledger [-h] [--no-csv] [--no-ledger] [--csv-file CSVFILE]

--- a/fints2ledger/csv2ledger.py
+++ b/fints2ledger/csv2ledger.py
@@ -7,6 +7,12 @@ class Csv2Ledger:
         self.config = config
 
     def convertToLedger(self):
+        print("""
+            Controls:
+                - enter 's' to skip an entry
+                - Ctrl + C to abort
+        """)
+
         writer = LedgerConverter(self.config)
         if os.path.exists(self.config["files"]["ledger_file"]):
             with open(self.config["files"]["ledger_file"], 'r') as existing_journal:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='fints2ledger',
-      version='0.6.0',
+      version='0.6.1',
       description='A tool for downloading transactions from FinTS banking APIs and sorting them into a ledger journal.',
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
With this PR the controls for the ledger conversion will be displayed once at program startup. Here is how it looks:
```
~$ fints2ledger

            Controls:
                - enter 's' to skip an entry
                - Ctrl + C to abort
        
{
 "date": "2020/08/21",
 "amount": "-17.05",
 "currency": "EUR",
 "payee": "...,
 "posting": "...",
 "purpose": "...",
 "debit_account": "assets:bank:checking"
}

credit_account: s
```