### PR TITLE
Add optional password prompt

### DIFF
--- a/fints2ledger/config.py
+++ b/fints2ledger/config.py
@@ -5,6 +5,7 @@ from mt940.models import Date
 import argparse
 import fints2ledger.utils as utils
 from pathlib import Path
+import getpass
 
 
 class Config:
@@ -12,7 +13,7 @@ class Config:
         'fints': {
             'blz': "<your bank's BLZ>",
             'account': '<your account number>',
-            'password': '<your banking password>',
+            'password': '<your password> (set to empty string if you prefer being prompted)',
             'endpoint': '<your bank fints endpoint>',
         },
         'ledger': {

--- a/fints2ledger/config.py
+++ b/fints2ledger/config.py
@@ -13,7 +13,7 @@ class Config:
         'fints': {
             'blz': "<your bank's BLZ>",
             'account': '<your account number>',
-            'password': '<your password> (set to empty string if you prefer being prompted)',
+            'password': '<your banking password> (set to empty string if you prefer being prompted)',
             'endpoint': '<your bank fints endpoint>',
         },
         'ledger': {

--- a/fints2ledger/fints2csv.py
+++ b/fints2ledger/fints2csv.py
@@ -1,6 +1,7 @@
 from fints2ledger.transaction_retriever import TRetriever
 from fints.client import FinTS3PinTanClient
 from fints2ledger.csv_converter import CsvConverter
+from fints2ledger.config import getpass
 from mt940.models import Date
 
 
@@ -14,7 +15,7 @@ class Fints2Csv:
         transactions = retrieve_transactions({
             "blz": self.config["fints"]["blz"],  # Your bank's BLZ
             "account": self.config["fints"]["account"],  # your account number
-            "password": self.config["fints"]["password"],
+            "password": self.config["fints"]["password"] if self.config["fints"]["password"] else getpass.getpass("Password: "),
             # e.g. 'https://fints.ing-diba.de/fints/'
             "endpoint": self.config["fints"]["endpoint"],
             "selected_account": self.config["fints"]["selectedAccount"],


### PR DESCRIPTION
I did not like the idea of storing my banking password as plain text in the `config.yml` so I added the option to leave the password field empty and be prompted via `getpass` instead. Other users may find this useful as well.

All credit goes to the authors of [pyfints](https://github.com/raphaelm/python-fints) since I took the two lines of code from their quickstart script 🙂 