### PR TITLE
Better config setup on first start

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In the `ledger` section you can use a regex match on any field of the transactio
 The `amount` field uses comparison symbols instead of a regex. Valid values are for example "<=90.5", "120.13", "> 200"
 
 Example: I do not want to enter a `credit_account` and `purpose` for my monthly recurring payments for the rent of my apartment. Same for my music streaming transactions. I can change the `config.yml` like this:
-```
+```yaml
 ledger:
   ...
   fills:
@@ -73,6 +73,18 @@ ledger:
       fill:
         credit_account: "expenses:monthly:musiccompany"
         purpose: "Monthly fee for music streaming"
+```
+To only fill out parts of the transaction while still being prompted for others, leave the value empty for the fields that you like to be prompted for.
+The following will fill out `credit_account` but still prompt for `purpose` (instead of taking the purpose from the original transaction).
+```yaml
+ledger:
+  ...
+  fills:
+    - match:
+        payee: "The Landlord"
+      fill:
+        credit_account: "expenses:monthly:rent"
+        purpose:
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -42,23 +42,11 @@ You can try out the program with the `demo` flag, which does not call any bankin
 fints2ledger --demo
 ```
 
-Next, go to your config to the newly created config file (default `~/.config/fints2ledger/config.yml`) and update your banking credentials in the `fints` section:
-```
-fints:
-  blz: "<your bank's BLZ>"
-  account: "<your account number>"
-  password: "<your banking password>"
-  endpoint: <your bank fints endpoint> # e.g.: https://fints.ing.de/fints for ING
-  selectedAccount: "<account number>" # defaults to the value from "account"
-                                      # useful when you have multiple accounts for the same login
-```
-
-When you are done, run
+To use a real connection run
 ```
 fints2ledger
 ```
-
-This will download the transactions from the last 90 days (by default) and tries to convert them to a ledger journal.
+and enter your banking transaction in the following form. This only needs to be done once.
 
 For a list of available command line arguments, run
 ```

--- a/src/Config/AppConfig.hs
+++ b/src/Config/AppConfig.hs
@@ -1,8 +1,8 @@
-module Config.AppConfig (AppConfig (..), getConfig) where
+module Config.AppConfig (AppConfig (..), makeAppConfig) where
 
 import Config.CliConfig (CliConfig (..))
 import Config.Files (ConfigDirectory)
-import Config.YamlConfig (FintsConfig, LedgerConfig, YamlConfig (..), getYamlConfig)
+import Config.YamlConfig (FintsConfig, LedgerConfig, YamlConfig (..))
 import Data.Time (Day)
 
 data AppConfig = Config
@@ -18,16 +18,14 @@ data AppConfig = Config
   }
   deriving (Show)
 
-getConfig :: CliConfig -> IO AppConfig
-getConfig cliConfig = do
-  yamlConfig <- getYamlConfig cliConfig.configDirectory
-  return $
-    Config
-      { fintsConfig = yamlConfig.fints
-      , ledgerConfig = yamlConfig.ledger
-      , configDirectory = cliConfig.configDirectory
-      , journalFile = cliConfig.journalFile
-      , startDate = cliConfig.startDate
-      , isDemo = cliConfig.isDemo
-      , pythonExecutable = cliConfig.pythonExecutable
-      }
+makeAppConfig :: CliConfig -> YamlConfig -> AppConfig
+makeAppConfig cliConfig yamlConfig =
+  Config
+    { fintsConfig = yamlConfig.fints
+    , ledgerConfig = yamlConfig.ledger
+    , configDirectory = cliConfig.configDirectory
+    , journalFile = cliConfig.journalFile
+    , startDate = cliConfig.startDate
+    , isDemo = cliConfig.isDemo
+    , pythonExecutable = cliConfig.pythonExecutable
+    }

--- a/src/Config/StartupChecks.hs
+++ b/src/Config/StartupChecks.hs
@@ -3,10 +3,14 @@ module Config.StartupChecks (runStartupChecks) where
 import Config.CliConfig (CliConfig (..))
 import Config.Files (ConfigDirectory (..), getConfigFilePath)
 import Config.YamlConfig (YamlConfig (..), defaultYamlConfig, writeYamlConfig)
+import Control.Exception (Exception, throw)
 import Control.Monad (unless)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import UI.ConfigUI (runConfigUI)
-import Utils ((??))
+
+newtype ConfigSetupAborted = ConfigSetupAborted String deriving (Show)
+
+instance Exception ConfigSetupAborted
 
 runStartupChecks :: CliConfig -> IO ()
 runStartupChecks cliConfig = do
@@ -16,4 +20,6 @@ runStartupChecks cliConfig = do
   configFileExists <- doesFileExist configFilePath
   unless configFileExists do
     maybeConfig <- runConfigUI defaultYamlConfig cliConfig.configDirectory
-    writeYamlConfig configFilePath defaultYamlConfig{fints = maybeConfig ?? defaultYamlConfig.fints}
+    case maybeConfig of
+      Just config -> writeYamlConfig configFilePath defaultYamlConfig{fints = config}
+      Nothing -> throw $ ConfigSetupAborted "Please fill out and save the config form before continuing."

--- a/src/Config/YamlConfig.hs
+++ b/src/Config/YamlConfig.hs
@@ -120,7 +120,7 @@ defaultYamlConfig =
         FintsConfig
           { blz = "<your banks BLZ>"
           , account = "<your account number>"
-          , password = Just $ Password "<your banking password>"
+          , password = Nothing
           , endpoint = "<your bank fints endpoint>"
           , selectedAccount = Nothing
           }

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -5,11 +5,11 @@ where
 
 import App (App, Env (..), PromptResult (..))
 import Completion (runCompletion)
-import Config.AppConfig (AppConfig (..), getConfig)
+import Config.AppConfig (AppConfig (..), makeAppConfig)
 import Config.CliConfig (CliConfig (..), getCliConfig)
 import Config.Files (getConfigFilePath)
 import Config.StartupChecks (runStartupChecks)
-import Config.YamlConfig (YamlConfig (..), getYamlConfig, writeYamlConfig)
+import Config.YamlConfig (YamlConfig (..), defaultYamlConfig, getYamlConfig, writeYamlConfig)
 import Control.Concurrent (threadDelay)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
@@ -31,9 +31,14 @@ runFints2Ledger :: IO ()
 runFints2Ledger = do
   cliConfig <- execParser =<< getCliConfig
 
-  runStartupChecks cliConfig
+  let command = getCommand cliConfig
 
-  appConfig <- getConfig cliConfig
+  appConfig <- case command of
+    RunDemo -> return $ makeAppConfig cliConfig defaultYamlConfig
+    _ -> do
+      runStartupChecks cliConfig
+      yamlConfig <- getYamlConfig cliConfig.configDirectory
+      return $ makeAppConfig cliConfig yamlConfig
 
   ensureFileExists appConfig.journalFile
 

--- a/src/Transactions.hs
+++ b/src/Transactions.hs
@@ -68,7 +68,7 @@ getTransactionsFromFinTS config = do
 getPassword :: IO Password
 getPassword = do
   Haskeline.runInputT Haskeline.defaultSettings do
-    maybePassword <- Haskeline.getPassword (Just '*') "Password: "
+    maybePassword <- Haskeline.getPassword (Just '*') "Banking Password: "
     Haskeline.outputStrLn ""
     return $ Password $ T.pack (maybePassword ?? "")
 

--- a/test/files/defaultConfig.yml
+++ b/test/files/defaultConfig.yml
@@ -2,7 +2,6 @@ fints:
   account: <your account number>
   blz: <your banks BLZ>
   endpoint: <your bank fints endpoint>
-  password: <your banking password>
 ledger:
   defaults:
     debit_account: assets:bank:checking


### PR DESCRIPTION
This improves on some issue for the first start, namely:
* When run with the `--demo` flag, the app will not ask for banking credentials anymore if none are stored in the config
* When aborting the config form on the first start, no default config with dummy credentials will be stored anymore. This allows the config form to popup on the next start, instead of trying to access the bank with dummy credentials.
* The default password is now empty, which should be a better default instead of some dummy value. The user will be prompted later for the password