### PR TITLE
Bring back csv support

### DIFF
--- a/fints2ledger.cabal
+++ b/fints2ledger.cabal
@@ -69,6 +69,7 @@ library
     , base16-bytestring
     , brick
     , bytestring
+    , cassava
     , containers
     , cryptohash-md5
     , dates
@@ -85,6 +86,7 @@ library
     , time
     , transformers
     , typed-process
+    , vector
     , vty
     , yaml
   default-language: GHC2021
@@ -106,6 +108,7 @@ executable fints2ledger
     , base16-bytestring
     , brick
     , bytestring
+    , cassava
     , containers
     , cryptohash-md5
     , dates
@@ -123,6 +126,7 @@ executable fints2ledger
     , time
     , transformers
     , typed-process
+    , vector
     , vty
     , yaml
   default-language: GHC2021
@@ -164,6 +168,7 @@ test-suite fints2ledger-test
     , base16-bytestring
     , brick
     , bytestring
+    , cassava
     , containers
     , cryptohash-md5
     , dates
@@ -183,6 +188,7 @@ test-suite fints2ledger-test
     , time
     , transformers
     , typed-process
+    , vector
     , vty
     , yaml
   default-language: GHC2021

--- a/package.yaml
+++ b/package.yaml
@@ -46,6 +46,8 @@ dependencies:
 - vty # underlying library for brick
 - lens # lenses to use with brick
 - generic-lens # automatically generate lenses
+- cassava # csv encoding/decoding
+- vector # list-like type, used by cassava
 
 language: GHC2021
 

--- a/src/Config/AppConfig.hs
+++ b/src/Config/AppConfig.hs
@@ -13,7 +13,6 @@ data AppConfig = Config
   , journalFile :: FilePath
   , -- the start date to pull the FinTS entries from (format YYYY/MM/DD)
     startDate :: Day
-  , isDemo :: Bool
   , pythonExecutable :: String
   }
   deriving (Show)
@@ -26,6 +25,5 @@ makeAppConfig cliConfig yamlConfig =
     , configDirectory = cliConfig.configDirectory
     , journalFile = cliConfig.journalFile
     , startDate = cliConfig.startDate
-    , isDemo = cliConfig.isDemo
     , pythonExecutable = cliConfig.pythonExecutable
     }

--- a/src/Config/CliConfig.hs
+++ b/src/Config/CliConfig.hs
@@ -4,7 +4,7 @@ import Config.Files (ConfigDirectory, getDefaultConfigDirectory)
 import Data.Dates (DateTime, dateTimeToDay, getCurrentDateTime, parseDate)
 import Data.Time (Day, addDays, defaultTimeLocale, formatTime)
 import Hledger (getCurrentDay)
-import Options.Applicative (Parser, ParserInfo, eitherReader, fullDesc, help, helper, info, long, metavar, option, progDesc, short, showDefault, showDefaultWith, strOption, switch, value, (<**>))
+import Options.Applicative (Parser, ParserInfo, eitherReader, fullDesc, help, helper, info, long, metavar, option, optional, progDesc, short, showDefault, showDefaultWith, strOption, switch, value, (<**>))
 
 data CliConfig = CliConfig
   { configDirectory :: ConfigDirectory
@@ -13,6 +13,8 @@ data CliConfig = CliConfig
   , pythonExecutable :: String
   , isDemo :: Bool
   , shouldEditConfig :: Bool
+  , toCsvFile :: Maybe FilePath
+  , fromCsvFile :: Maybe FilePath
   }
   deriving (Show)
 
@@ -66,6 +68,20 @@ pythonExecutableOption =
       <> showDefault
       <> value "python3"
 
+toCsvFile :: Parser (Maybe FilePath)
+toCsvFile =
+  optional $
+    strOption $
+      long "to-csv-file"
+        <> help "Write transactions to this csv file instead of to a ledger journal"
+
+fromCsvFile :: Parser (Maybe FilePath)
+fromCsvFile =
+  optional $
+    strOption $
+      long "from-csv-file"
+        <> help "Read transactions from this csv file instead of from a FinTS endpoint"
+
 getCliParser :: IO (Parser CliConfig)
 getCliParser = do
   defaultConfigDirectory <- getDefaultConfigDirectory
@@ -79,6 +95,8 @@ getCliParser = do
       <*> pythonExecutableOption
       <*> demoOption
       <*> configOption
+      <*> toCsvFile
+      <*> fromCsvFile
 
 getCliConfig :: IO (ParserInfo CliConfig)
 getCliConfig = do

--- a/src/Config/CliConfig.hs
+++ b/src/Config/CliConfig.hs
@@ -1,10 +1,15 @@
-module Config.CliConfig (getCliConfig, CliConfig (..)) where
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Config.CliConfig (getCliConfig, CliConfig (..), CsvMode (..), csvModeFromConfig) where
 
 import Config.Files (ConfigDirectory, getDefaultConfigDirectory)
 import Data.Dates (DateTime, dateTimeToDay, getCurrentDateTime, parseDate)
 import Data.Time (Day, addDays, defaultTimeLocale, formatTime)
 import Hledger (getCurrentDay)
 import Options.Applicative (Parser, ParserInfo, eitherReader, fullDesc, help, helper, info, long, metavar, option, optional, progDesc, short, showDefault, showDefaultWith, strOption, switch, value, (<**>))
+
+data CsvMode = ToFile FilePath | FromFile FilePath | NoCsv | FromTo deriving (Show)
 
 data CliConfig = CliConfig
   { configDirectory :: ConfigDirectory
@@ -13,8 +18,8 @@ data CliConfig = CliConfig
   , pythonExecutable :: String
   , isDemo :: Bool
   , shouldEditConfig :: Bool
-  , toCsvFile :: Maybe FilePath
   , fromCsvFile :: Maybe FilePath
+  , toCsvFile :: Maybe FilePath
   }
   deriving (Show)
 
@@ -68,15 +73,15 @@ pythonExecutableOption =
       <> showDefault
       <> value "python3"
 
-toCsvFile :: Parser (Maybe FilePath)
-toCsvFile =
+toCsvFileOption :: Parser (Maybe FilePath)
+toCsvFileOption =
   optional $
     strOption $
       long "to-csv-file"
         <> help "Write transactions to this csv file instead of to a ledger journal"
 
-fromCsvFile :: Parser (Maybe FilePath)
-fromCsvFile =
+fromCsvFileOption :: Parser (Maybe FilePath)
+fromCsvFileOption =
   optional $
     strOption $
       long "from-csv-file"
@@ -87,16 +92,16 @@ getCliParser = do
   defaultConfigDirectory <- getDefaultConfigDirectory
   ninetyDaysAgo <- addDays (-90) <$> getCurrentDay
   currentDateTime <- getCurrentDateTime
-  return $
-    CliConfig
-      <$> configDirectoryOption defaultConfigDirectory
-      <*> journalFileOption
-      <*> startDateOption currentDateTime ninetyDaysAgo
-      <*> pythonExecutableOption
-      <*> demoOption
-      <*> configOption
-      <*> toCsvFile
-      <*> fromCsvFile
+  return $ do
+    configDirectory <- configDirectoryOption defaultConfigDirectory
+    journalFile <- journalFileOption
+    startDate <- startDateOption currentDateTime ninetyDaysAgo
+    pythonExecutable <- pythonExecutableOption
+    isDemo <- demoOption
+    shouldEditConfig <- configOption
+    toCsvFile <- toCsvFileOption
+    fromCsvFile <- fromCsvFileOption
+    pure CliConfig{..}
 
 getCliConfig :: IO (ParserInfo CliConfig)
 getCliConfig = do
@@ -111,3 +116,9 @@ getCliConfig = do
 mapLeft :: (a -> c) -> Either a b -> Either c b
 mapLeft f (Left x) = Left $ f x
 mapLeft _ (Right x) = Right x
+
+csvModeFromConfig :: CliConfig -> CsvMode
+csvModeFromConfig config =
+  case config.toCsvFile of
+    Just toCsvPath -> maybe (ToFile toCsvPath) (const FromTo) (config.fromCsvFile)
+    Nothing -> maybe NoCsv FromFile (config.fromCsvFile)

--- a/src/Config/CliConfig.hs
+++ b/src/Config/CliConfig.hs
@@ -78,6 +78,7 @@ toCsvFileOption =
   optional $
     strOption $
       long "to-csv-file"
+        <> metavar "FILE"
         <> help "Write transactions to this csv file instead of to a ledger journal"
 
 fromCsvFileOption :: Parser (Maybe FilePath)
@@ -85,6 +86,7 @@ fromCsvFileOption =
   optional $
     strOption $
       long "from-csv-file"
+        <> metavar "FILE"
         <> help "Read transactions from this csv file instead of from a FinTS endpoint"
 
 getCliParser :: IO (Parser CliConfig)

--- a/src/Transactions.hs
+++ b/src/Transactions.hs
@@ -43,8 +43,7 @@ getExampleTransactions = do
 getTransactionsFromCsv :: FilePath -> IO [Transaction]
 getTransactionsFromCsv path = do
   csvContents <- BS.readFile path
-  let result = Csv.decodeByName csvContents
-  case result of
+  case Csv.decodeByName csvContents of
     Right (_header, rows) -> return $ toList rows
     Left message -> throw $ CsvDecodeError message
 

--- a/test/PromptSpec.hs
+++ b/test/PromptSpec.hs
@@ -143,8 +143,7 @@ spec = do
 testConfig :: AppConfig
 testConfig =
   Config
-    { isDemo = True
-    , journalFile = "testJournal.ledger"
+    { journalFile = "testJournal.ledger"
     , startDate = ModifiedJulianDay 0
     , configDirectory = "testConfigDirectory"
     , fintsConfig = error "Tests should need a fintsConfig"


### PR DESCRIPTION
Adds back csv support, see issue https://github.com/MoritzR/fints2ledger/issues/27

Two new config flags have been added:
* `--to-csv-file FILE` write the transactions from FinTS into a csv file instead of a ledger journal
* `--from-csv-file FILE` reads the transactions from a csv file in the same format instead of from FinTS