### PR TITLE
Use LF csv line endings

### DIFF
--- a/src/Config/CliConfig.hs
+++ b/src/Config/CliConfig.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Config.CliConfig (getCliConfig, CliConfig (..), CsvMode (..), csvModeFromConfig) where
+module Config.CliConfig (getCliConfig, CliConfig (..)) where
 
 import Config.Files (ConfigDirectory, getDefaultConfigDirectory)
 import Data.Dates (DateTime, dateTimeToDay, getCurrentDateTime, parseDate)
 import Data.Time (Day, addDays, defaultTimeLocale, formatTime)
 import Hledger (getCurrentDay)
 import Options.Applicative (Parser, ParserInfo, eitherReader, fullDesc, help, helper, info, long, metavar, option, optional, progDesc, short, showDefault, showDefaultWith, strOption, switch, value, (<**>))
-
-data CsvMode = ToFile FilePath | FromFile FilePath | NoCsv | FromTo deriving (Show)
 
 data CliConfig = CliConfig
   { configDirectory :: ConfigDirectory
@@ -118,9 +116,3 @@ getCliConfig = do
 mapLeft :: (a -> c) -> Either a b -> Either c b
 mapLeft f (Left x) = Left $ f x
 mapLeft _ (Right x) = Right x
-
-csvModeFromConfig :: CliConfig -> CsvMode
-csvModeFromConfig config =
-  case config.toCsvFile of
-    Just toCsvPath -> maybe (ToFile toCsvPath) (const FromTo) config.fromCsvFile
-    Nothing -> maybe NoCsv FromFile config.fromCsvFile

--- a/src/Transactions.hs
+++ b/src/Transactions.hs
@@ -48,7 +48,7 @@ getTransactionsFromCsv path = do
     Left message -> throwIO $ CsvDecodeError message
 
 convertTransactionsToCsv :: FilePath -> [Transaction] -> IO ()
-convertTransactionsToCsv path = BS.writeFile path . Csv.encodeDefaultOrderedByName
+convertTransactionsToCsv path = BS.writeFile path . Csv.encodeDefaultOrderedByNameWith Csv.defaultEncodeOptions{Csv.encUseCrLf = False}
 
 getTransactionsFromFinTS :: AppConfig -> IO [Transaction]
 getTransactionsFromFinTS config = do

--- a/src/UI/ConfigUI.hs
+++ b/src/UI/ConfigUI.hs
@@ -50,8 +50,8 @@ draw configDirectory state =
   [ form
       <+> vBorder
       <+> hLimit 20 help
-        <=> configText
-        <=> controls
+      <=> configText
+      <=> controls
   ]
  where
   form = renderForm state.form

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -17,14 +17,14 @@ import Data.Text.Lazy.Encoding qualified as TL
 byteStringToString :: ByteString -> String
 byteStringToString = TL.unpack . TL.decodeUtf8
 
-encodeAsString :: ToJSON a => a -> String
+encodeAsString :: (ToJSON a) => a -> String
 encodeAsString = byteStringToString . encode
 
 (??) :: Maybe a -> a -> a
 Nothing ?? a = a
 Just a ?? _ = a
 
-orElseThrow :: Exception e => Either String a -> (String -> e) -> IO a
+orElseThrow :: (Exception e) => Either String a -> (String -> e) -> IO a
 orElseThrow eitherAB toException = case eitherAB of
   Left err -> throwIO $ toException err
   Right value -> return value


### PR DESCRIPTION
Makes the produced csv file with the `--to-csv-file` option use LF line endings instead of CRLF line endings.
This makes it consistent with the previous python version of fints2ledger and fixes https://github.com/MoritzR/fints2ledger/issues/31