### PR TITLE
Fix number format

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -24,7 +24,7 @@ import Options.Applicative (execParser)
 import Prompt (transactionsToLedger)
 import System.Console.Haskeline (getInputLine)
 import System.Directory (doesFileExist)
-import Transactions (Transaction, writeTransactionsToCsv, getExampleTransactions, getTransactionsFromCsv, getTransactionsFromFinTS)
+import Transactions (Transaction, getExampleTransactions, getTransactionsFromCsv, getTransactionsFromFinTS, writeTransactionsToCsv)
 import UI.ConfigUI (runConfigUI)
 import Utils (createFile)
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -24,7 +24,7 @@ import Options.Applicative (execParser)
 import Prompt (transactionsToLedger)
 import System.Console.Haskeline (getInputLine)
 import System.Directory (doesFileExist)
-import Transactions (Transaction, convertTransactionsToCsv, getExampleTransactions, getTransactionsFromCsv, getTransactionsFromFinTS)
+import Transactions (Transaction, writeTransactionsToCsv, getExampleTransactions, getTransactionsFromCsv, getTransactionsFromFinTS)
 import UI.ConfigUI (runConfigUI)
 import Utils (createFile)
 
@@ -53,7 +53,7 @@ run cliConfig appConfig = getTransactions >>= convertTransactions
     if cliConfig.isDemo
       then getExampleTransactions
       else maybe (getTransactionsFromFinTS appConfig) getTransactionsFromCsv cliConfig.fromCsvFile
-  convertTransactions = maybe (convertTransactionsForConfig appConfig) convertTransactionsToCsv cliConfig.toCsvFile
+  convertTransactions = maybe (convertTransactionsForConfig appConfig) writeTransactionsToCsv cliConfig.toCsvFile
 
 editConfig :: AppConfig -> IO ()
 editConfig appConfig = do

--- a/src/Prompt.hs
+++ b/src/Prompt.hs
@@ -2,6 +2,7 @@ module Prompt (transactionsToLedger) where
 
 import App (App, Env (..), PromptResult (..), printText)
 import Config.AppConfig (AppConfig (..))
+import Config.Files (templateFile)
 import Config.YamlConfig (Fill, Filling (..), LedgerConfig (..))
 import Control.Arrow ((>>>))
 import Control.Monad (forM_, when)
@@ -25,7 +26,6 @@ import Text.Regex.TDFA (AllTextMatches (getAllTextMatches), (=~))
 import Transactions (Amount (..), Transaction (..))
 import Utils (calculateMd5Value, formatDouble, toLazyTemplateMap)
 import Prelude hiding (appendFile, putStrLn, readFile)
-import Config.Files (templateFile)
 
 {- | A Map of key/value pairs that will be used to fill the template file
 We fill these values step by step by:
@@ -82,8 +82,8 @@ insertTransaction transaction =
 
 insertCreditDebit :: Transaction -> TemplateMap -> TemplateMap
 insertCreditDebit transaction =
-  insert "debit" (T.pack $ show transaction.amount)
-    >>> insert "credit" (T.pack $ show $ -transaction.amount)
+  insert "debit" (formatDouble transaction.amount.amount)
+    >>> insert "credit" (formatDouble $ -transaction.amount.amount)
 
 getMd5 :: LedgerConfig -> TemplateMap -> Text
 getMd5 ledgerConfig templateMap = calculateMd5Value md5Values

--- a/src/Transactions.hs
+++ b/src/Transactions.hs
@@ -6,6 +6,7 @@ module Transactions (
   getExampleTransactions,
   getTransactionsFromCsv,
   writeTransactionsToCsv,
+  transactionsToCsv,
   Transaction (..),
   Amount (..),
 )
@@ -22,6 +23,7 @@ import Data.Csv (DefaultOrdered, FromField, FromNamedRecord, ToField, ToNamedRec
 import Data.Csv qualified as Csv
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import Data.Text.IO qualified as TIO
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TL
@@ -30,10 +32,10 @@ import Data.Vector (toList)
 import GHC.Generics (Generic)
 import Hledger (getCurrentDay)
 import System.Console.Haskeline qualified as Haskeline
+import System.IO (hFlush)
 import System.IO.Temp (withSystemTempFile)
 import System.Process.Typed (ExitCode (ExitFailure, ExitSuccess), readProcess, shell)
-import Utils (encodeAsString, orElseThrow, (??))
-import System.IO (hFlush)
+import Utils (encodeAsString, formatDouble, orElseThrow, (??))
 
 getExampleTransactions :: IO [Transaction]
 getExampleTransactions = do
@@ -49,7 +51,10 @@ getTransactionsFromCsv path = do
     Left message -> throwIO $ CsvDecodeError message
 
 writeTransactionsToCsv :: FilePath -> [Transaction] -> IO ()
-writeTransactionsToCsv path = BS.writeFile path . Csv.encodeDefaultOrderedByNameWith Csv.defaultEncodeOptions{Csv.encUseCrLf = False}
+writeTransactionsToCsv path = BS.writeFile path . transactionsToCsv
+
+transactionsToCsv :: [Transaction] -> BS.ByteString
+transactionsToCsv = Csv.encodeDefaultOrderedByNameWith Csv.defaultEncodeOptions{Csv.encUseCrLf = False}
 
 getTransactionsFromFinTS :: AppConfig -> IO [Transaction]
 getTransactionsFromFinTS config = do
@@ -72,13 +77,13 @@ getTransactionsFromFinTS config = do
     hFlush handle
 
     let shellCommand =
-          shell
-            $ "FINTS2LEDGER_ARGS='"
-            ++ encodeAsString pyfintsArgs
-            ++ "' "
-            ++ config.pythonExecutable
-            ++ " "
-            ++ path
+          shell $
+            "FINTS2LEDGER_ARGS='"
+              ++ encodeAsString pyfintsArgs
+              ++ "' "
+              ++ config.pythonExecutable
+              ++ " "
+              ++ path
     (exitCode, stdOut, stdErr) <- readProcess shellCommand
     case exitCode of
       ExitSuccess -> Aeson.eitherDecode stdOut `orElseThrow` TransactionDecodeError
@@ -108,13 +113,16 @@ data PyFintsArguments = PyFintsArguments
   deriving (Generic, ToJSON)
 
 newtype Amount = Amount {amount :: Double}
-  deriving newtype (Num, Show, Eq, FromField, ToField)
+  deriving newtype (Num, Show, Eq, FromField)
+
+instance ToField Amount where
+  toField amount = T.encodeUtf8 $ formatDouble amount.amount
 
 instance FromJSON Amount where
   parseJSON value = Amount . read <$> Aeson.parseJSON value
 
 instance ToJSON Amount where
-  toJSON value = Aeson.toJSON value.amount
+  toJSON value = Aeson.toJSON $ formatDouble value.amount
 
 data Transaction = Transaction
   { date :: Text

--- a/src/Transactions.hs
+++ b/src/Transactions.hs
@@ -5,7 +5,7 @@ module Transactions (
   getTransactionsFromFinTS,
   getExampleTransactions,
   getTransactionsFromCsv,
-  convertTransactionsToCsv,
+  writeTransactionsToCsv,
   Transaction (..),
   Amount (..),
 )
@@ -48,8 +48,8 @@ getTransactionsFromCsv path = do
     Right (_header, rows) -> return $ toList rows
     Left message -> throwIO $ CsvDecodeError message
 
-convertTransactionsToCsv :: FilePath -> [Transaction] -> IO ()
-convertTransactionsToCsv path = BS.writeFile path . Csv.encodeDefaultOrderedByNameWith Csv.defaultEncodeOptions{Csv.encUseCrLf = False}
+writeTransactionsToCsv :: FilePath -> [Transaction] -> IO ()
+writeTransactionsToCsv path = BS.writeFile path . Csv.encodeDefaultOrderedByNameWith Csv.defaultEncodeOptions{Csv.encUseCrLf = False}
 
 getTransactionsFromFinTS :: AppConfig -> IO [Transaction]
 getTransactionsFromFinTS config = do

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -13,6 +13,7 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TL
+import Text.Printf (printf)
 
 byteStringToString :: ByteString -> String
 byteStringToString = TL.unpack . TL.decodeUtf8
@@ -45,7 +46,7 @@ calculateMd5Value md5Values =
 formatDouble :: Double -> Text
 formatDouble double
   | fromInteger floored == double = T.pack $ show floored
-  | otherwise = T.pack $ show double
+  | otherwise = T.pack $ printf "%0.2f" double
  where
   floored = floor double :: Integer
 

--- a/test/PromptSpec.hs
+++ b/test/PromptSpec.hs
@@ -134,7 +134,7 @@ spec = do
                     , appendFile = \_filePath text -> modifyIORef ioRef (<> text)
                     }
 
-            runToLedger [testTransaction] env
+            runToLedger [testTransaction, testTransaction{amount = Amount 0.01}] env
             readIORef ioRef
 
       goldenTextFile "test/files/snapshot.ledger" getSnapshot

--- a/test/TransactionSpec.hs
+++ b/test/TransactionSpec.hs
@@ -4,8 +4,9 @@ import Config.Files (exampleFile)
 import Data.Aeson qualified as Aeson
 import Data.Text.Lazy (fromStrict)
 import Data.Text.Lazy.Encoding (encodeUtf8)
-import Test.Syd (Spec, describe, it, shouldBe)
-import Transactions (Amount (Amount), Transaction (..))
+import Test.Syd (Spec, describe, it, shouldBe, shouldContain)
+import Transactions (Amount (Amount), Transaction (..), transactionsToCsv)
+import Utils (byteStringToString)
 
 spec :: Spec
 spec = do
@@ -23,3 +24,16 @@ spec = do
             , payee = "VISA KAUFLAND"
             , purpose = "NR XXXX 1234 KAUFUMSATZ120092309482309480239"
             }
+
+    it "writes 0.01 to csv (instead of 1.0e-2)" do
+      let transaction =
+            Transaction
+              { date = "2022/03/23"
+              , amount = Amount 0.01
+              , currency = "EUR"
+              , posting = "Lastschrifteinzug"
+              , payee = "VISA KAUFLAND"
+              , purpose = "NR XXXX 1234 KAUFUMSATZ120092309482309480239"
+              }
+
+      byteStringToString (transactionsToCsv [transaction]) `shouldContain` "0.01"

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -10,3 +10,5 @@ spec = do
       formatDouble 29.34 `shouldBe` "29.34"
     it "formats integers without decimal places" do
       formatDouble 29.0 `shouldBe` "29"
+    it "doesn't use e notaion for smaller numbers" do
+      formatDouble 0.01 `shouldBe` "0.01"

--- a/test/files/snapshot.ledger
+++ b/test/files/snapshot.ledger
@@ -4,3 +4,8 @@
     ; md5sum: 5abd61b9de15c3115519a5f1b4ac7992
     assets:test                                                     EUR 99.99
     expenses:test                                                   EUR -99.99
+
+01/01/2023 test payee test posting test purpose
+    ; md5sum: 5abd61b9de15c3115519a5f1b4ac7992
+    assets:test                                                     EUR 0.01
+    expenses:test                                                   EUR -0.01


### PR DESCRIPTION
Fixes `0.01` getting shown as `1.0e-2` in both csv and ledger files.

See issue https://github.com/MoritzR/fints2ledger/issues/32