### PR TITLE
Read template from config directory

### DIFF
--- a/src/Config/Files.hs
+++ b/src/Config/Files.hs
@@ -9,13 +9,11 @@ import Data.Map (Map, fromList, (!))
 import Data.String (IsString)
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
-import System.Directory (doesFileExist, getHomeDirectory)
+import System.Directory (XdgDirectory (XdgConfig), doesFileExist, getXdgDirectory)
 import System.FilePath ((</>))
 
 getDefaultConfigDirectory :: IO ConfigDirectory
-getDefaultConfigDirectory = do
-  homeDirectory <- getHomeDirectory
-  return $ ConfigDirectory $ homeDirectory </> ".config" </> "fints2ledger"
+getDefaultConfigDirectory = ConfigDirectory <$> getXdgDirectory XdgConfig "fints2ledger"
 
 getConfigFilePath :: ConfigDirectory -> FilePath
 getConfigFilePath configDirectory = configDirectory.get </> "config.yml"

--- a/src/Config/Files.hs
+++ b/src/Config/Files.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Config.Files (getDefaultConfigDirectory, getConfigFilePath, templateFile, exampleFile, pyfintsFile, ConfigDirectory (..)) where
+module Config.Files (getDefaultConfigDirectory, getConfigFilePath, getTemplateFile, exampleFile, pyfintsFile, ConfigDirectory (..)) where
 
 import Data.ByteString (ByteString)
 import Data.FileEmbed (embedDir)
@@ -9,7 +9,7 @@ import Data.Map (Map, fromList, (!))
 import Data.String (IsString)
 import Data.Text (Text)
 import Data.Text.Encoding qualified as T
-import System.Directory (getHomeDirectory)
+import System.Directory (doesFileExist, getHomeDirectory)
 import System.FilePath ((</>))
 
 getDefaultConfigDirectory :: IO ConfigDirectory
@@ -20,8 +20,13 @@ getDefaultConfigDirectory = do
 getConfigFilePath :: ConfigDirectory -> FilePath
 getConfigFilePath configDirectory = configDirectory.get </> "config.yml"
 
-templateFile :: Text
-templateFile = T.decodeUtf8 $ dataFiles ! "template.txt"
+getTemplateFile :: ConfigDirectory -> (FilePath -> IO Text) -> IO Text
+getTemplateFile configDirectory readTextFile = do
+  let templateFilePath = configDirectory.get </> "template.txt"
+  fileExists <- doesFileExist templateFilePath
+  if fileExists
+    then readTextFile templateFilePath
+    else return $ T.decodeUtf8 $ dataFiles ! "template.txt"
 
 exampleFile :: Text
 exampleFile = T.decodeUtf8 $ dataFiles ! "example.json"


### PR DESCRIPTION
Reads the template file from the config directory. This allows for easier configuration, as previously one had to edit the template file in the data directory next to the executable.
The template was hidden like that on purpose, but until other ways of customizing the ledger entry are present, this still needs to be a feature.