### PR TITLE
Fix changed hashes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ git clone https://github.com/MoritzR/fints2ledger
 cd fints2ledger
 stack test
 ```
+There are some snapshot tests, which can be updated with
+```
+stack test --test-arguments="--golden-reset"
+```
+in case they fail because of an intentional change.
 
 You can run the application with
 ```

--- a/src/Config/Files.hs
+++ b/src/Config/Files.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Config.Files (getDefaultConfigDirectory, getConfigFilePath, getTemplateFile, exampleFile, pyfintsFile, ConfigDirectory (..)) where
+module Config.Files (getDefaultConfigDirectory, defaultTemplateFile, getConfigFilePath, getTemplateFile, exampleFile, pyfintsFile, ConfigDirectory (..)) where
 
 import Data.ByteString (ByteString)
 import Data.FileEmbed (embedDir)
@@ -24,7 +24,10 @@ getTemplateFile configDirectory readTextFile = do
   fileExists <- doesFileExist templateFilePath
   if fileExists
     then readTextFile templateFilePath
-    else return $ T.decodeUtf8 $ dataFiles ! "template.txt"
+    else return defaultTemplateFile
+
+defaultTemplateFile :: Text
+defaultTemplateFile = T.decodeUtf8 $ dataFiles ! "template.txt"
 
 exampleFile :: Text
 exampleFile = T.decodeUtf8 $ dataFiles ! "example.json"

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -46,7 +46,7 @@ calculateMd5Value md5Values =
 formatDouble :: Double -> Text
 formatDouble double
   | fromInteger floored == double = T.pack $ show floored
-  | otherwise = T.pack $ printf "%0.2f" double
+  | otherwise = T.pack $ printf "%f" double
  where
   floored = floor double :: Integer
 

--- a/test/PromptSpec.hs
+++ b/test/PromptSpec.hs
@@ -65,6 +65,11 @@ spec = do
       let env =
             testEnv
               { readFile = const $ return "; md5sum: 5abd61b9de15c3115519a5f1b4ac7992"
+              , config = testConfig {
+                ledgerConfig = testConfig.ledgerConfig {
+                  md5 = ["purpose"]
+                }
+              }
               , promptForEntry = \_templateMap key -> do
                   liftIO $ modifyIORef ioRef (++ [key])
                   return $ Result "test input"
@@ -149,7 +154,7 @@ testConfig =
     , ledgerConfig =
         LedgerConfig
           { defaults = fromList [("debit_account", "assets:test")]
-          , md5 = ["purpose"]
+          , md5 = ["date", "payee", "purpose", "amount"]
           , prompts = ["credit_account"]
           , fills = []
           }

--- a/test/PromptSpec.hs
+++ b/test/PromptSpec.hs
@@ -134,7 +134,7 @@ spec = do
                     , appendFile = \_filePath text -> modifyIORef ioRef (<> text)
                     }
 
-            runToLedger [testTransaction, testTransaction{amount = Amount 0.01}] env
+            runToLedger [testTransaction, testTransaction{amount = Amount 0.01}, testTransaction {amount = Amount 6.2}] env
             readIORef ioRef
 
       goldenTextFile "test/files/snapshot.ledger" getSnapshot

--- a/test/PromptSpec.hs
+++ b/test/PromptSpec.hs
@@ -9,11 +9,11 @@ import Data.IORef (modifyIORef, newIORef, readIORef)
 import Data.List (isInfixOf)
 import Data.Map (empty, fromList)
 import Data.Text qualified as T
-import Data.Text.IO qualified as TIO
 import Data.Time.Calendar (Day (ModifiedJulianDay))
 import Prompt (transactionsToLedger)
 import Test.Syd (Spec, describe, goldenTextFile, it, shouldBe, shouldContain)
 import Transactions (Amount (Amount), Transaction (..))
+import Config.Files (defaultTemplateFile)
 
 spec :: Spec
 spec = do
@@ -180,7 +180,7 @@ testEnv =
     , putStrLn = const $ return ()
     , readFile = \path ->
         if "template.txt" `isInfixOf` path
-          then TIO.readFile path
+          then return defaultTemplateFile
           else return ""
     , appendFile = \_filePath _text -> return ()
     , sleep = return ()

--- a/test/files/snapshot.ledger
+++ b/test/files/snapshot.ledger
@@ -1,16 +1,16 @@
 
 
 01/01/2023 test payee test posting test purpose
-    ; md5sum: 5abd61b9de15c3115519a5f1b4ac7992
+    ; md5sum: 5f85873caca053389a226077dfcf1eab
     assets:test                                                     EUR 99.99
     expenses:test                                                   EUR -99.99
 
 01/01/2023 test payee test posting test purpose
-    ; md5sum: 5abd61b9de15c3115519a5f1b4ac7992
+    ; md5sum: ba74fb33fc25b1fe90387c67ec375b2e
     assets:test                                                     EUR 0.01
     expenses:test                                                   EUR -0.01
 
 01/01/2023 test payee test posting test purpose
-    ; md5sum: 5abd61b9de15c3115519a5f1b4ac7992
+    ; md5sum: 850b1e3adaa6a79806bc6c5792bf0ef4
     assets:test                                                     EUR 6.2
     expenses:test                                                   EUR -6.2

--- a/test/files/snapshot.ledger
+++ b/test/files/snapshot.ledger
@@ -11,6 +11,6 @@
     expenses:test                                                   EUR -0.01
 
 01/01/2023 test payee test posting test purpose
-    ; md5sum: 850b1e3adaa6a79806bc6c5792bf0ef4
+    ; md5sum: 743a882437a289416cee64fba47fe22f
     assets:test                                                     EUR 6.2
     expenses:test                                                   EUR -6.2

--- a/test/files/snapshot.ledger
+++ b/test/files/snapshot.ledger
@@ -9,3 +9,8 @@
     ; md5sum: 5abd61b9de15c3115519a5f1b4ac7992
     assets:test                                                     EUR 0.01
     expenses:test                                                   EUR -0.01
+
+01/01/2023 test payee test posting test purpose
+    ; md5sum: 5abd61b9de15c3115519a5f1b4ac7992
+    assets:test                                                     EUR 6.2
+    expenses:test                                                   EUR -6.2


### PR DESCRIPTION
This fixes an issue cause by commit https://github.com/MoritzR/fints2ledger/commit/a131f6aa4299aba74b0bc46154d0174ecabf0e08

In addition to fixes an issue with the display of `0.01`, it also changed the number format to always include two decimal places, if there was a decimal place.
For example `6.5` was changed to `6.50`.

This unfortunately caused problems if the amount was used as a values for the md5 hash based duplication detection (which is the default).
Entries created by previous fints2ledger versions would not correctly be identified as a duplicate (and vice versa).

This PR changes the number format back to how is was before, while retaining the fix for values like `0.01`.